### PR TITLE
Strip the leading slash of file paths

### DIFF
--- a/repository/repository.go
+++ b/repository/repository.go
@@ -3,6 +3,7 @@ package repository
 import (
 	"fmt"
 	"io"
+	"path"
 
 	"github.com/Masterminds/semver"
 	"github.com/cfg8er/pkg/repository/semverref"
@@ -32,23 +33,23 @@ func CloneBare(URL string) (Repository, error) {
 // FileOpenAtRev opens a file at a given path at a given Git revision, eg.
 // https://kernel.org/pub/software/scm/git/docs/gitrevisions.html. Returns an
 // open io.ReadCloser, file size, and error.
-func (r *Repository) FileOpenAtRev(path string, rev plumbing.Revision) (io.ReadCloser, int64, error) {
+func (r *Repository) FileOpenAtRev(filePath string, rev plumbing.Revision) (io.ReadCloser, int64, error) {
 	ref, err := r.ResolveRevision(rev)
 	if err != nil {
 		return nil, 0, fmt.Errorf("Revision resolve of %s: %s", ref, err)
 	}
-	return r.fileOpenAtHash(path, *ref)
+	return r.fileOpenAtHash(filePath, *ref)
 }
 
 // FileOpenAtRef opens a file at a given path at given reference. Returns an open io.ReadCloser,
 // file size, and error.
-func (r *Repository) FileOpenAtRef(path string, ref plumbing.Reference) (io.ReadCloser, int64, error) {
-	return r.fileOpenAtHash(path, ref.Hash())
+func (r *Repository) FileOpenAtRef(filePath string, ref plumbing.Reference) (io.ReadCloser, int64, error) {
+	return r.fileOpenAtHash(filePath, ref.Hash())
 }
 
 // fileOpenAtHash opens a file at a given path at a given hash. Returns an open io.ReadCloser,
 // file size, and error.
-func (r *Repository) fileOpenAtHash(path string, hash plumbing.Hash) (io.ReadCloser, int64, error) {
+func (r *Repository) fileOpenAtHash(filePath string, hash plumbing.Hash) (io.ReadCloser, int64, error) {
 	commit, err := r.CommitObject(hash)
 	if err != nil {
 		return nil, 0, fmt.Errorf("Commit object of %v: %s", hash, err)
@@ -59,9 +60,14 @@ func (r *Repository) fileOpenAtHash(path string, hash plumbing.Hash) (io.ReadClo
 		return nil, 0, fmt.Errorf("Tree of commit %v: %s", commit.TreeHash, err)
 	}
 
-	entry, err := tree.FindEntry(path)
+	// If filePath has a leading slash remove it as tree entries don't have a leading slash.
+	if path.IsAbs(filePath) {
+		filePath = filePath[1:]
+	}
+
+	entry, err := tree.FindEntry(filePath)
 	if err != nil {
-		return nil, 0, fmt.Errorf("Path in tree %s: %s", path, err)
+		return nil, 0, fmt.Errorf("Path in tree %s: %s", filePath, err)
 	}
 
 	object, err := r.BlobObject(entry.Hash)

--- a/repository/repository_test.go
+++ b/repository/repository_test.go
@@ -51,8 +51,8 @@ func TestRepository_FileOpenAtRev(t *testing.T) {
 	}
 
 	type args struct {
-		path string
-		rev  plumbing.Revision
+		filePath string
+		rev      plumbing.Revision
 	}
 	tests := []struct {
 		name    string
@@ -62,44 +62,44 @@ func TestRepository_FileOpenAtRev(t *testing.T) {
 	}{
 		{
 			name:    "Reference not found",
-			args:    args{path: "CHANGELOG", rev: plumbing.Revision("asdf1234")},
+			args:    args{filePath: "CHANGELOG", rev: plumbing.Revision("asdf1234")},
 			want:    nil,
 			wantErr: true,
 		},
 		{
 			name:    "Open and read CHANGELOG at refs/heads/master",
-			args:    args{path: "CHANGELOG", rev: plumbing.Revision("refs/heads/master")},
+			args:    args{filePath: "CHANGELOG", rev: plumbing.Revision("refs/heads/master")},
 			want:    []byte("Initial changelog\n"),
 			wantErr: false,
 		},
 		{
 			name:    "Open and read CHANGELOG at refs/remotes/origin/branch",
-			args:    args{path: "CHANGELOG", rev: plumbing.Revision("refs/remotes/origin/branch")},
+			args:    args{filePath: "CHANGELOG", rev: plumbing.Revision("refs/remotes/origin/branch")},
 			want:    []byte("Initial changelog\n"),
 			wantErr: false,
 		},
 		{
 			name: "Open and read vendor/foo.go at refs/heads/master",
-			args: args{path: "vendor/foo.go", rev: plumbing.Revision("refs/heads/master")},
+			args: args{filePath: "vendor/foo.go", rev: plumbing.Revision("refs/heads/master")},
 			want: []byte("package main\n\nimport \"fmt\"\n\nfunc main() {\n	fmt.Println(\"Hello, playground\")\n}\n"),
 			wantErr: false,
 		},
 		{
 			name:    "Open and read CHANGELOG at 6ecf0ef2c2dffb796033e5a02219af86ec6584e5",
-			args:    args{path: "CHANGELOG", rev: plumbing.Revision("6ecf0ef2c2dffb796033e5a02219af86ec6584e5")},
+			args:    args{filePath: "CHANGELOG", rev: plumbing.Revision("6ecf0ef2c2dffb796033e5a02219af86ec6584e5")},
 			want:    []byte("Initial changelog\n"),
 			wantErr: false,
 		},
 		{
 			name:    "Open and read CHANGELOG at short ref master",
-			args:    args{path: "CHANGELOG", rev: plumbing.Revision("master")},
+			args:    args{filePath: "CHANGELOG", rev: plumbing.Revision("master")},
 			want:    []byte("Initial changelog\n"),
 			wantErr: false,
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got, _, err := r.FileOpenAtRev(tt.args.path, tt.args.rev)
+			got, _, err := r.FileOpenAtRev(tt.args.filePath, tt.args.rev)
 
 			if err != nil {
 				if !tt.wantErr {
@@ -132,8 +132,8 @@ func TestRepository_fileOpenAtHash(t *testing.T) {
 	}
 
 	type args struct {
-		path string
-		hash plumbing.Hash
+		filePath string
+		hash     plumbing.Hash
 	}
 	tests := []struct {
 		name    string
@@ -143,38 +143,38 @@ func TestRepository_fileOpenAtHash(t *testing.T) {
 	}{
 		{
 			name:    "Non-existent commit hash",
-			args:    args{path: "CHANGELOG", hash: plumbing.NewHash("0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f")},
+			args:    args{filePath: "CHANGELOG", hash: plumbing.NewHash("0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f")},
 			want:    nil,
 			wantErr: true,
 		},
 		{
 			name:    "Non-existent file path",
-			args:    args{path: "asdf/ghjk", hash: plumbing.NewHash("6ecf0ef2c2dffb796033e5a02219af86ec6584e5")},
+			args:    args{filePath: "asdf/ghjk", hash: plumbing.NewHash("6ecf0ef2c2dffb796033e5a02219af86ec6584e5")},
 			want:    nil,
 			wantErr: true,
 		},
 		{
 			name:    "Open and read CHANGELOG at 6ecf0ef2c2dffb796033e5a02219af86ec6584e5",
-			args:    args{path: "CHANGELOG", hash: plumbing.NewHash("6ecf0ef2c2dffb796033e5a02219af86ec6584e5")},
+			args:    args{filePath: "CHANGELOG", hash: plumbing.NewHash("6ecf0ef2c2dffb796033e5a02219af86ec6584e5")},
 			want:    []byte("Initial changelog\n"),
 			wantErr: false,
 		},
 		{
 			name:    "Open and read CHANGELOG at a remote branch commit e8d3ffab552895c19b9fcf7aa264d277cde33881",
-			args:    args{path: "CHANGELOG", hash: plumbing.NewHash("e8d3ffab552895c19b9fcf7aa264d277cde33881")},
+			args:    args{filePath: "CHANGELOG", hash: plumbing.NewHash("e8d3ffab552895c19b9fcf7aa264d277cde33881")},
 			want:    []byte("Initial changelog\n"),
 			wantErr: false,
 		},
 		{
 			name: "Open and read vendor/foo.go at 6ecf0ef2c2dffb796033e5a02219af86ec6584e5",
-			args: args{path: "vendor/foo.go", hash: plumbing.NewHash("6ecf0ef2c2dffb796033e5a02219af86ec6584e5")},
+			args: args{filePath: "vendor/foo.go", hash: plumbing.NewHash("6ecf0ef2c2dffb796033e5a02219af86ec6584e5")},
 			want: []byte("package main\n\nimport \"fmt\"\n\nfunc main() {\n	fmt.Println(\"Hello, playground\")\n}\n"),
 			wantErr: false,
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got, _, err := r.fileOpenAtHash(tt.args.path, tt.args.hash)
+			got, _, err := r.fileOpenAtHash(tt.args.filePath, tt.args.hash)
 			if err != nil {
 				if !tt.wantErr {
 					t.Errorf("Repository.fileOpenAtHash() error = %v, wantErr %v", err, tt.wantErr)


### PR DESCRIPTION
Tree objects don't have leading slashes so we need to remove it if included.

The various functions need their path argument renamed to filePath to not overlap with the path package.