### PR TITLE
Cloning repos moved into a goroutine and done lazily in the background

### DIFF
--- a/internal/config/load.go
+++ b/internal/config/load.go
@@ -6,12 +6,12 @@ import (
 )
 
 // LoadConfig opens the filePath using micro/go-config to scan it onto
-// a map[String]Repo.
-func LoadConfig(filePath string) (map[string]Repo, error) {
+// a map[String]*Repo.
+func LoadConfig(filePath string) (map[string]*Repo, error) {
 	// Create new config
 	conf := config.NewConfig()
 
-	repos := map[string]Repo{}
+	repos := map[string]*Repo{}
 
 	// Load file source
 	f := file.WithPath(filePath)

--- a/internal/config/load_test.go
+++ b/internal/config/load_test.go
@@ -12,13 +12,13 @@ func TestLoadConfig(t *testing.T) {
 	tests := []struct {
 		name    string
 		args    args
-		want    map[string]Repo
+		want    map[string]*Repo
 		wantErr bool
 	}{
 		{
 			name:    "Non-existant path",
 			args:    args{filePath: "/non-existant/path"},
-			want:    map[string]Repo{},
+			want:    map[string]*Repo{},
 			wantErr: true,
 		},
 		/*{
@@ -30,7 +30,7 @@ func TestLoadConfig(t *testing.T) {
 		{
 			name: "Load example yaml config",
 			args: args{filePath: "../../fixtures/config/config.yaml"},
-			want: map[string]Repo{
+			want: map[string]*Repo{
 				"cfg8er-fixture": {
 					URL:               "https://github.com/cfg8er/fixture.git",
 					UpdateFrequency:   600,
@@ -51,7 +51,7 @@ func TestLoadConfig(t *testing.T) {
 		{
 			name: "Load example json config",
 			args: args{filePath: "../../fixtures/config/config.json"},
-			want: map[string]Repo{
+			want: map[string]*Repo{
 				"cfg8er-fixture": {
 					URL:               "https://github.com/cfg8er/fixture.git",
 					UpdateFrequency:   600,


### PR DESCRIPTION
Launch cloneRepos into a goroutine that ranges over the new updateRepoCh channel. An error on cloning or fetching updates on a repo is no longer fatal, but will print an error to stdout for now. config.Repo's ClonedRepo attribute is now a pointer to repository.Repository so we can share the cloned repo without having to reassign the entire config.Repo to the global map. Closes #19.